### PR TITLE
fix: omit data-race panic on `GC()`

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -374,7 +374,7 @@ func TestSessionManager_GC(t *testing.T) {
 	}
 	for _, shard := range manager.shards {
 		shard.lock.Lock()
-		l := len(shard.m)
+		l := len(*shard.m)
 		shard.lock.Unlock()
 		require.Equal(t, N/sd, l)
 	}
@@ -382,7 +382,7 @@ func TestSessionManager_GC(t *testing.T) {
 	sum := 0
 	for _, shard := range manager.shards {
 		shard.lock.Lock()
-		l := len(shard.m)
+		l := len(*shard.m)
 		shard.lock.Unlock()
 		sum += l
 	}

--- a/session.go
+++ b/session.go
@@ -161,7 +161,7 @@ func (self *SessionMap) Get(key interface{}) interface{} {
 }
 
 // Set value for specific key，and return itself
-func (self *SessionMap) WithValue(key interface{}, val interface{}) Session {
+func (self *SessionMap) WithValue(key, val interface{}) Session {
 	if self == nil {
 		return nil
 	}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
    `GC()` will change the underlying map pointer with holding read lock, which `Load()` may be read this map also with read lock. In our design, this is allowed since GC only replace this map with the same content (only shrink its capacity). But go runtime can not correctly recognize this case. Therefore, we use `atomic` operations to omit `-race` panic.
- It seems there is no affection on performance:
```
name                                   old time/op    new time/op    delta
SessionManager_CurSession/sync-16        23.8ns ± 0%    23.5ns ± 0%   ~     (p=1.000 n=1+1)
SessionManager_CurSession/parallel-16    13.7ns ± 0%    12.9ns ± 0%   ~     (p=1.000 n=1+1)
GLS_Get/sync-16                          62.9ns ± 0%    51.2ns ± 0%   ~     (p=1.000 n=1+1)
GLS_Get/parallel-16                      21.6ns ± 0%    19.8ns ± 0%   ~     (p=1.000 n=1+1)
```
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
